### PR TITLE
save/restore pyfints state

### DIFF
--- a/pretix_banktool/main.py
+++ b/pretix_banktool/main.py
@@ -71,6 +71,7 @@ def setup(type):
     click.echo('')
     click.echo(click.style('Other information', fg='blue'))
     filename = click.prompt('Configuration file', default=api_organizer + '.cfg', type=click.Path(exists=False))
+    state_file = click.prompt('State file', default=api_organizer + '.state', type=click.Path(exists=False))
 
     config = configparser.ConfigParser()
     config['banktool'] = {
@@ -82,7 +83,8 @@ def setup(type):
             'endpoint': endpoint,
             'username': username,
             'iban': iban,
-            'pin': pin
+            'pin': pin,
+            'state_file': state_file,
         }
     config['pretix'] = {
         'server': api_server,

--- a/pretix_banktool/testing.py
+++ b/pretix_banktool/testing.py
@@ -23,6 +23,12 @@ def test_fints(config):
         product_id='459BE10AAEE93C6AA90BE6FE3',
         product_version=__version__
     )
+    if 'state_file' in config['fints']:
+        try:
+            with open(config['fints']['state_file'], 'rb') as f2:
+                f.set_data(f2.read())
+        except:
+            pass
 
     if not f.get_current_tan_mechanism():
         f.fetch_tan_mechanisms()
@@ -92,6 +98,10 @@ def test_fints(config):
         else:
             click.echo('No recent transaction found. Please check if this is correct.')
 
+    state = f.deconstruct(including_private=True)
+    if 'state_file' in config['fints']:
+        with open(config['fints']['state_file'], 'wb') as f2:
+            f2.write(state)
 
 def test_pretix(config):
     click.echo('Testing pretix connection...')

--- a/pretix_banktool/upload.py
+++ b/pretix_banktool/upload.py
@@ -32,6 +32,12 @@ def upload_transactions(config, days=30, pending=False, bank_ids=False, ignore=N
         product_id='459BE10AAEE93C6AA90BE6FE3',
         product_version=__version__
     )
+    if 'state_file' in config['fints']:
+        try:
+            with open(config['fints']['state_file'], 'rb') as f2:
+                f.set_data(f2.read())
+        except:
+            pass
 
     if not f.get_current_tan_mechanism():
         f.fetch_tan_mechanisms()
@@ -167,3 +173,8 @@ def upload_transactions(config, days=30, pending=False, bank_ids=False, ignore=N
                 sys.exit(2)
         else:
             click.echo('No recent transaction found.')
+
+    state = f.deconstruct(including_private=True)
+    if 'state_file' in config['fints']:
+        with open(config['fints']['state_file'], 'wb') as f2:
+            f2.write(state)


### PR DESCRIPTION
Re-using the same system-id is required for some banks (Sparkasse) to allow requesting recent transactions without requiring a new TAN each time.